### PR TITLE
修复null空指针错误

### DIFF
--- a/src/main/java/cn/evole/onebot/sdk/util/BotUtils.java
+++ b/src/main/java/cn/evole/onebot/sdk/util/BotUtils.java
@@ -221,7 +221,7 @@ public class BotUtils {
     public static String arrayMsgToCode(List<ArrayMsg> arrayMsgs) {
         StringBuilder builder = new StringBuilder();
         for (ArrayMsg item : arrayMsgs) {
-            if (!item.getType().equals(MsgTypeEnum.text)) {
+            if (item.getType() != null && !item.getType()。equals(MsgTypeEnum.text)) {
                 builder.append("[CQ:").append(item.getType());
                 item.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(escape(v)));
                 builder.append("]");

--- a/src/main/java/cn/evole/onebot/sdk/util/BotUtils.java
+++ b/src/main/java/cn/evole/onebot/sdk/util/BotUtils.java
@@ -221,7 +221,7 @@ public class BotUtils {
     public static String arrayMsgToCode(List<ArrayMsg> arrayMsgs) {
         StringBuilder builder = new StringBuilder();
         for (ArrayMsg item : arrayMsgs) {
-            if (item.getType() != null && !item.getType()。equals(MsgTypeEnum.text)) {
+            if (item.getType() != null && !item.getType().equals(MsgTypeEnum.text)) {
                 builder.append("[CQ:").append(item.getType());
                 item.getData().forEach((k, v) -> builder.append(",").append(k).append("=").append(escape(v)));
                 builder.append("]");


### PR DESCRIPTION
群消息发文件时，会get到null从而发生空指针错误，这里直接做了一个是null就不予执行，防止线程卡死